### PR TITLE
Correção do Erro Fatal que ocorria na exclusão de um Track.

### DIFF
--- a/App/gripy_app.py
+++ b/App/gripy_app.py
@@ -554,6 +554,8 @@ class GripyApp(wx.App):
         if fdlg.ShowModal() == wx.ID_OK:
             file_name = fdlg.GetFilename()
             dir_name = fdlg.GetDirectory()
+            if not file_name.endswith('.pgg'):
+                file_name += '.pgg'
             self.save_project_data(os.path.join(dir_name, file_name))
         fdlg.Destroy()   
 

--- a/UI/mvc_classes/plotter_log.py
+++ b/UI/mvc_classes/plotter_log.py
@@ -114,8 +114,10 @@ class LogPlotController(PlotterController):
         try:
             title_parent = self.view.main_panel.top_splitter
             track_parent = self.view.main_panel.bottom_splitter
-            track_controller.view.label.SetDropTarget(None)
-            track_controller.view.track.SetDropTarget(None) 
+            # TODO: As linhas abaixo faziam com que a aplicação 'voasse' quando um Track
+            # fosse excluido. Verificar se o comentário será mantido. 
+            #track_controller.view.label.SetDropTarget(None)
+            #track_controller.view.track.SetDropTarget(None) 
             title_parent.DetachWindow(track_controller.view.label)
             track_parent.DetachWindow(track_controller.view.track)        
             track_controller.view.label.Hide()


### PR DESCRIPTION
Atualização obrigatória

Correção do Erro Fatal que ocorria na exclusão de um Track (informado por @Canhaco @rtabelini )
Também foi corrigido um bug no Linux (informado por @Canhaco) onde ao salvar o projeto a extensão '.pgg' não era incluída no nome de arquivo, assim o arquivo não era localizado no método 'Abrir Projeto', pois esse seleciona somente arquivos com a extensão '.pgg'.

TODO: Verificar problema com wx.DropTarget ao arrastar objeto para o Track, pois não o Drag and Drop não funciona em algumas situações.

